### PR TITLE
get state boundaries as inline svg

### DIFF
--- a/layout/templates/main_fig.mustache
+++ b/layout/templates/main_fig.mustache
@@ -1,4 +1,5 @@
 <div id=mainFig>
+  {{{ initial_svg }}}
 </div>
 
 {{{ script }}}

--- a/scripts/publish/inline_svg.R
+++ b/scripts/publish/inline_svg.R
@@ -1,0 +1,6 @@
+publish.inline_svg <- function(viz) {
+  svg <- xml2::read_xml(viz[["location"]])
+  xml_string <- xml2::as_xml_document(svg)
+  
+  return(as.character(xml_string))
+}

--- a/src/app.js
+++ b/src/app.js
@@ -5,24 +5,10 @@ var d3 = require('d3');
 import {load_dv_data} from './modules/data_loading';
 import {add_circles} from './modules/circles';
 
-// setup
-var h = 200;
-var w = 700;
-var margin = {
-  top: 20,
-  bottom: 60,
-  left: 60,
-  right: 60
-};
-var plotwidth = w - margin.left - margin.right;
-var plotheight = h - margin.top - margin.bottom;
-
-// create an svg element
+// use existing svg element
 var svg = d3.select("body").select("#mainFig")
-    .append("svg")
-      .attr("id", "plotarea") // id == #plot in css, class == .plot in css
-      .attr("width", w)
-      .attr("height", h);
+      .select("svg")
+        .attr("id", "plotarea");
     
 var dv_stats_data = load_dv_data();
 

--- a/viz.yaml
+++ b/viz.yaml
@@ -127,8 +127,16 @@ publish:
     publisher: section
     depends:
       script: bundle_js
+      initial_svg: svg_state_map
     context: 
+      initial_svg: initial_svg
       script: script
+  - 
+    id: svg_state_map
+    location: cache/state_boundaries.svg
+    mimetype: "image/svg"
+    publisher: inline_svg
+    scripts: scripts/publish/inline_svg.R
   -
     id: bundle_js
     location: dist/bundle.js


### PR DESCRIPTION
I haven't added the correct locations for the gages yet, but this gets the d3 code using the basemap svg! Added a special publisher in order to do this. We should consider adding this to vizlab in the future. This might have a small conflict with #13 in `app.js`.

Here's what we've got now:

![image](https://user-images.githubusercontent.com/13220910/42089361-5c25ef8a-7b62-11e8-8a98-0bf934ce62d1.png)
