### PR TITLE
Implement canvas research task - points + interactive legend

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -51,11 +51,17 @@ Promise.all([dv_stats_data]).then(function(data) {
       find_closest_point(this, data[0]);
     });
     
-  d3.select('#overlayLegend').selectAll("circle").on("click", function() {
+  d3.select('#overlayLegend').selectAll("circle")
+  .on("mouseover", function() {
     d3.select(this).attr("stroke", "orange").attr("stroke-width", 2);
     var legend_color_str = d3.select(this).attr("fill");
     create_circles(data[0], canvas_context, scale_colors_fxns, fig_cfg, legend_cfg,
                    true, legend_color_str);
+  })
+  .on("mouseout", function() {
+    // reset circles
+    create_circles(data[0], canvas_context, scale_colors_fxns, fig_cfg, legend_cfg, 
+                   false, null);
   });
   
 });

--- a/js/app.js
+++ b/js/app.js
@@ -4,7 +4,7 @@ var d3 = require('d3');
 // webpack import functions
 import {load_dv_data} from './modules/data_loading';
 import {create_circles, create_color_scale_function, add_color_legend} from './modules/circles';
-import {clone_states, clone_legend, add_circle_selector, find_closest_point} from './modules/interactivity';
+import {clone_states, clone_legend, add_circle_selector, find_closest_point, add_placeholder} from './modules/interactivity';
 
 // set up configs
 var fig_cfg = {
@@ -40,6 +40,7 @@ add_color_legend(scale_colors_fxns, legend_cfg);
 add_circle_selector();
 clone_states(fig_cfg);
 clone_legend(fig_cfg, legend_cfg);
+add_placeholder(fig_cfg);
 
 Promise.all([dv_stats_data]).then(function(data) {
   create_circles(data[0], canvas_context, scale_colors_fxns, fig_cfg, legend_cfg, 

--- a/js/app.js
+++ b/js/app.js
@@ -4,14 +4,18 @@ var d3 = require('d3');
 // webpack import functions
 import {load_dv_data} from './modules/data_loading';
 import {add_circles, create_color_scale_function, add_color_legend} from './modules/circles';
-import {clone_states, add_circle_selector, find_closest_point} from './modules/interactivity';
+import {clone_states, clone_legend, add_circle_selector, find_closest_point} from './modules/interactivity';
 
 // set up configs
-var legend_config = {
-  translate_x: 300,
-  translate_y: 40,
-  circle_radius: 10
-};
+var fig_cfg = {
+      width: 960,
+      height: 600
+    },
+    legend_cfg = {
+      translate_x: 300,
+      translate_y: 40,
+      circle_radius: 10
+    };
 
 // use existing svg element and add some attributes
 d3.select("#mainFig").select("svg")
@@ -22,8 +26,8 @@ d3.select("#mainFig").select("svg")
 // create canvas layer
 var canvas = d3.select("#mainFig").append('canvas')
       .attr('id', "mainCanvas")
-      .attr('width', 960)
-      .attr('height', 600)
+      .attr('width', fig_cfg.width)
+      .attr('height', fig_cfg.width)
       .style("position", "absolute");
 
 var canvas_context = canvas.node().getContext('2d'),
@@ -31,9 +35,10 @@ var canvas_context = canvas.node().getContext('2d'),
     dv_stats_data = load_dv_data();
 
 // add different figure features
-clone_states();
-add_color_legend(scale_colors_fxns, legend_config);
+add_color_legend(scale_colors_fxns, legend_cfg);
 add_circle_selector();
+clone_states(fig_cfg);
+clone_legend(fig_cfg, legend_cfg);
 
 Promise.all([dv_stats_data]).then(function(data) {
   add_circles(data[0], canvas_context, scale_colors_fxns);
@@ -43,4 +48,3 @@ Promise.all([dv_stats_data]).then(function(data) {
       find_closest_point(this, data[0]);
     });
 });
-

--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,13 @@ import {load_dv_data} from './modules/data_loading';
 import {add_circles, create_color_scale_function, add_color_legend} from './modules/circles';
 import {clone_states, add_circle_selector, find_closest_point} from './modules/interactivity';
 
+// set up configs
+var legend_config = {
+  translate_x: 300,
+  translate_y: 40,
+  circle_radius: 10
+};
+
 // use existing svg element and add some attributes
 d3.select("#mainFig").select("svg")
     .attr("id", "plotarea")
@@ -24,8 +31,8 @@ var canvas_context = canvas.node().getContext('2d'),
     dv_stats_data = load_dv_data();
 
 // add different figure features
-add_color_legend(scale_colors_fxns);
 clone_states();
+add_color_legend(scale_colors_fxns, legend_config);
 add_circle_selector();
 
 Promise.all([dv_stats_data]).then(function(data) {

--- a/js/app.js
+++ b/js/app.js
@@ -6,15 +6,35 @@ import {load_dv_data} from './modules/data_loading';
 import {add_circles, create_color_scale_function, add_color_legend} from './modules/circles';
 
 // use existing svg element
-var svg = d3.select("body").select("#mainFig")
-      .select("svg")
-        .attr("id", "plotarea");
-        
+var mainfig = d3.select("body").select("#mainFig");
+var svgoriginal = mainfig.select("svg")
+      .attr("id", "plotarea")
+      .style("z-index", -10)
+      .style("position", "absolute");
+
+// create canvas layer
+var canvas = mainfig.append('canvas')
+      .attr('id', "mainCanvas")
+      .attr('width', 960)
+      .attr('height', 600)
+      .style("position", "absolute");
+
+var canvas_context = canvas.node().getContext('2d');
+
+//clone states SVG for transparent click layer
+var content = svgoriginal.html();
+var svg = mainfig.append('svg')
+      .html(content)
+      .attr('id', 'overlayStates')
+      .attr('width', 960)
+      .attr('height', 600)
+      .style('opacity', 0);
+  
 var scale_colors_fxns = create_color_scale_function();
 var dv_stats_data = load_dv_data();
 add_color_legend(scale_colors_fxns);
 
 Promise.all([dv_stats_data]).then(function(data) {
-  add_circles(data[0], scale_colors_fxns);
+  add_circles(data[0], canvas_context, scale_colors_fxns);
 });
 

--- a/js/app.js
+++ b/js/app.js
@@ -4,43 +4,29 @@ var d3 = require('d3');
 // webpack import functions
 import {load_dv_data} from './modules/data_loading';
 import {add_circles, create_color_scale_function, add_color_legend} from './modules/circles';
-import {find_closest_point} from './modules/interactivity';
+import {clone_states, add_circle_selector, find_closest_point} from './modules/interactivity';
 
-// use existing svg element
-var mainfig = d3.select("body").select("#mainFig");
-var svgoriginal = mainfig.select("svg")
-      .attr("id", "plotarea")
-      .style("z-index", -10)
-      .style("position", "absolute");
+// use existing svg element and add some attributes
+d3.select("#mainFig").select("svg")
+    .attr("id", "plotarea")
+    .style("z-index", -10)
+    .style("position", "absolute");
 
 // create canvas layer
-var canvas = mainfig.append('canvas')
+var canvas = d3.select("#mainFig").append('canvas')
       .attr('id', "mainCanvas")
       .attr('width', 960)
       .attr('height', 600)
       .style("position", "absolute");
 
-var canvas_context = canvas.node().getContext('2d');
+var canvas_context = canvas.node().getContext('2d'),
+    scale_colors_fxns = create_color_scale_function(),
+    dv_stats_data = load_dv_data();
 
-//clone states SVG for transparent click layer
-var content = svgoriginal.html();
-var svg = mainfig.append('svg')
-      .html(content)
-      .attr('id', 'overlayStates')
-      .attr('width', 960)
-      .attr('height', 600)
-      .style('opacity', 0);
-
-svgoriginal.append('circle')
-      .attr("id", "siteHighlighter")
-      .attr("r", 8)
-      .attr("z-index", 100)
-      .style("fill", "blue")
-      .style("opacity", 0);
-      
-var scale_colors_fxns = create_color_scale_function();
-var dv_stats_data = load_dv_data();
+// add different figure features
 add_color_legend(scale_colors_fxns);
+clone_states();
+add_circle_selector();
 
 Promise.all([dv_stats_data]).then(function(data) {
   add_circles(data[0], canvas_context, scale_colors_fxns);

--- a/js/app.js
+++ b/js/app.js
@@ -3,7 +3,7 @@ var d3 = require('d3');
 
 // webpack import functions
 import {load_dv_data} from './modules/data_loading';
-import {add_circles, create_color_scale_function, add_color_legend} from './modules/circles';
+import {create_circles, create_color_scale_function, add_color_legend} from './modules/circles';
 import {clone_states, clone_legend, add_circle_selector, find_closest_point} from './modules/interactivity';
 
 // set up configs
@@ -14,7 +14,8 @@ var fig_cfg = {
     legend_cfg = {
       translate_x: 300,
       translate_y: 40,
-      circle_radius: 10
+      circle_radius: 10,
+      num_bins: 17
     };
 
 // use existing svg element and add some attributes
@@ -31,7 +32,7 @@ var canvas = d3.select("#mainFig").append('canvas')
       .style("position", "absolute");
 
 var canvas_context = canvas.node().getContext('2d'),
-    scale_colors_fxns = create_color_scale_function(),
+    scale_colors_fxns = create_color_scale_function(legend_cfg),
     dv_stats_data = load_dv_data();
 
 // add different figure features
@@ -41,10 +42,19 @@ clone_states(fig_cfg);
 clone_legend(fig_cfg, legend_cfg);
 
 Promise.all([dv_stats_data]).then(function(data) {
-  add_circles(data[0], canvas_context, scale_colors_fxns);
+  create_circles(data[0], canvas_context, scale_colors_fxns, fig_cfg, legend_cfg, 
+                 false, null);
   
   d3.select('#overlayStates')
     .on("click", function () {
       find_closest_point(this, data[0]);
     });
+    
+  d3.select('#overlayLegend').selectAll("circle").on("click", function() {
+    d3.select(this).attr("stroke", "orange").attr("stroke-width", 2);
+    var legend_color_str = d3.select(this).attr("fill");
+    create_circles(data[0], canvas_context, scale_colors_fxns, fig_cfg, legend_cfg,
+                   true, legend_color_str);
+  });
+  
 });

--- a/js/app.js
+++ b/js/app.js
@@ -4,6 +4,7 @@ var d3 = require('d3');
 // webpack import functions
 import {load_dv_data} from './modules/data_loading';
 import {add_circles, create_color_scale_function, add_color_legend} from './modules/circles';
+import {find_closest_point} from './modules/interactivity';
 
 // use existing svg element
 var mainfig = d3.select("body").select("#mainFig");
@@ -29,12 +30,24 @@ var svg = mainfig.append('svg')
       .attr('width', 960)
       .attr('height', 600)
       .style('opacity', 0);
-  
+
+svgoriginal.append('circle')
+      .attr("id", "siteHighlighter")
+      .attr("r", 8)
+      .attr("z-index", 100)
+      .style("fill", "blue")
+      .style("opacity", 0);
+      
 var scale_colors_fxns = create_color_scale_function();
 var dv_stats_data = load_dv_data();
 add_color_legend(scale_colors_fxns);
 
 Promise.all([dv_stats_data]).then(function(data) {
   add_circles(data[0], canvas_context, scale_colors_fxns);
+  
+  d3.select('#overlayStates')
+    .on("click", function () {
+      find_closest_point(this, data[0]);
+    });
 });
 

--- a/js/modules/circles.js
+++ b/js/modules/circles.js
@@ -54,24 +54,24 @@ function create_color_scale_function(num_colors) {
   });
 }
 
-function add_color_legend(scale_colors_fxn) {
+function add_color_legend(scale_colors_fxn, legend_cfg) {
   
-  var num_colors = scale_colors_fxn.legend.range().length,
-      circle_radius = 10;
+  var num_colors = scale_colors_fxn.legend.range().length;
   
   var legend = d3.select("#plotarea")
     .append("g")
       .attr("id", "legend")
-      .attr("transform", "translate(" + 300 + "," + 40 + ")");
+      .attr("transform", 
+            "translate(" + legend_cfg.translate_x + "," + legend_cfg.translate_y + ")");
   
   legend.selectAll(".legend_point")
     .data(d3.range(num_colors))
     .enter()
     .append("circle")
       .classed("legend_point", true)
-      .attr("cx", function(d) { return d*circle_radius*2.2; })
+      .attr("cx", function(d) { return d*legend_cfg.circle_radius*2.2; })
       .attr("cy", function(d) { return 0; })
-      .attr("r", circle_radius)
+      .attr("r", legend_cfg.circle_radius)
       .attr("fill", function(d) { return scale_colors_fxn.legend(d); })
       .attr("stroke", "transparent")
       .on("mouseover", function(d) {

--- a/js/modules/circles.js
+++ b/js/modules/circles.js
@@ -1,24 +1,18 @@
 
-function add_circles(dv_stats_data, scale_colors_fxn) {
-
-  d3.select("#plotarea").selectAll(".gage_point")
-    .data(dv_stats_data)
-    .enter()
-    .append("circle")
-      .classed("gage_point", true)
-      .attr("cx", function(d) { return d.x; })
-      .attr("cy", function(d) { return d.y; })
-      .attr("r", 2)
-      .attr("fill", function(d) { return scale_colors_fxn.circles(d.per); })
-      .attr("stroke", "transparent")
-      .on("mouseover", function(d) {
-        d3.select(this).attr("fill", "orange");
-        console.log(d.site_no);
-      })
-      .on("mouseout", function() {
-        d3.select(this)
-          .attr("fill", function(d) { return scale_colors_fxn.circles(d.per); });
-      });
+function add_circles(dv_stats_data, canvas_context, scale_colors_fxn) {
+  
+  canvas_context.beginPath();
+  for (let i in dv_stats_data) {
+    var radius = 2,
+        scale = 2,
+        point = dv_stats_data[i];
+    if (scale > 2) radius = 1;
+    canvas_context.fillStyle = scale_colors_fxn.circles(point.per);
+    canvas_context.moveTo(point.x + radius, point.y);
+    canvas_context.arc(point.x, point.y, radius, 0, 2 * Math.PI);
+  }
+  canvas_context.fill();
+  
 }
 
 function create_color_scale_function(num_colors) {

--- a/js/modules/circles.js
+++ b/js/modules/circles.js
@@ -1,30 +1,62 @@
 
-function add_circles(dv_stats_data, canvas_context, scale_colors_fxn) {
+function create_circles(dv_stats_data, canvas_context, scale_colors_fxns, fig_cfg,
+                        legend_cfg, is_legend_action, selected_color) {
   
-  canvas_context.beginPath();
-  for (let i in dv_stats_data) {
-    var radius = 2,
-        scale = 2,
-        point = dv_stats_data[i];
-    if (scale > 2) radius = 1;
-    canvas_context.fillStyle = scale_colors_fxn.circles(point.per);
-    canvas_context.moveTo(point.x + radius, point.y);
-    canvas_context.arc(point.x, point.y, radius, 0, 2 * Math.PI);
+  var radius = 2,
+      scale = 2;
+  if (scale > 2) radius = 1;
+  
+  canvas_context.clearRect(0, 0, fig_cfg.width, fig_cfg.height);
+  
+  for (let b in d3.range(legend_cfg.num_bins)) {
+    // make one path per color
+    var color_category = scale_colors_fxns.legend(b);
+    canvas_context.beginPath();
+    
+    for (let i in dv_stats_data) {
+      var point = dv_stats_data[i],
+          color_point = scale_colors_fxns.circles(point.per);
+      
+      // are we drawing the point in this loop iteration?
+      if (color_point === color_category) {
+        // we are drawing the point with default style
+        canvas_context.fillStyle = color_point;
+        canvas_context.strokeStyle = color_point;
+        
+        // now we need to check if the style should change
+        // is it part of a legend hover action?
+        if(is_legend_action) {
+          // is it the selected category?
+          if(color_category === selected_color) {
+            // then the radius should be made much bigger
+            radius = 4;
+            if (scale > 2) radius = 3;
+          } else {
+            //otherwise make a regular hollow point
+            canvas_context.fillStyle = "transparent";
+          }
+        }
+        
+        // now define the point geometry
+        canvas_context.moveTo(point.x + radius, point.y);
+        canvas_context.arc(point.x, point.y, radius, 0, 2 * Math.PI);
+      }
+      
+    }
+    // finish the current path (this is what actually does the final drawing)
+    canvas_context.fill();
+    canvas_context.stroke();
   }
-  canvas_context.fill();
-  
 }
 
-function create_color_scale_function(num_colors) {
+function create_color_scale_function(legend_cfg) {
   
   // this function requires the following d3 libraries
   // d3-color.v1.min.js
   // d3-interpolate.v1.min.js
   // d3-scale-chromatic.v1.min.js
   
-  if(num_colors === undefined) { 
-    num_colors = 17; // 17 color categories by default
-  }
+  var num_colors = legend_cfg.num_bins; 
   var color_indices = d3.range(num_colors);
   
   //d3.interpolateRdBu expects numbers between 0 and 1
@@ -112,4 +144,4 @@ function add_color_legend(scale_colors_fxn, legend_cfg) {
       });
 }
 
-export {add_circles, create_color_scale_function, add_color_legend};
+export {create_circles, create_color_scale_function, add_color_legend};

--- a/js/modules/interactivity.js
+++ b/js/modules/interactivity.js
@@ -27,11 +27,20 @@ function clone_legend(fig_cfg, legend_cfg) {
         .attr("transform", 
             // need to transform so that they line up correctly
             // the circles start getting placed at the top left corner of the svg
-            "translate(" + (legend_cfg.translate_x) + "," + (legend_cfg.translate_y) + ")")
+            "translate(" + (legend_cfg.translate_x-circle_radius) + "," + 
+            (legend_cfg.translate_y-circle_radius) + ")")
         .style('opacity', 0)
-        .style("position", "absolute")
-        .html(content);
-  
+        .style("position", "absolute");
+    
+  // add circles
+  overlayLegend.append('g')
+    .attr("transform", 
+      // need to transform so that they line up correctly
+      // the circles start getting placed at the top left corner of the svg
+      "translate(" + (circle_radius) + "," + 
+      (circle_radius) + ")")
+    .html(content);
+      
 }
 
 function add_circle_selector() {
@@ -86,4 +95,5 @@ function add_placeholder(fig_cfg) {
         .style('opacity', 0)
         .attr("z-index", -100);
 }
+
 export {clone_states, clone_legend, add_circle_selector, find_closest_point, add_placeholder};

--- a/js/modules/interactivity.js
+++ b/js/modules/interactivity.js
@@ -12,17 +12,25 @@ function clone_states(fig_cfg) {
 }
 
 function clone_legend(fig_cfg, legend_cfg) {
+  var circle_radius = d3.select("#legend").select("circle").attr("r"),
+      num_circles = d3.select("#legend").selectAll("circle").size(),
+      first_position = d3.select("#legend").select("circle:first-child").attr("cx"),
+      last_position = d3.select("#legend").select("circle:last-child").attr("cx");
   //clone legend SVG for transparent click layer
   var content = d3.select("#legend").html();
   var overlayLegend = d3.select("#mainFig").append('svg')
-        .attr('width', fig_cfg.width)
-        .attr('height', fig_cfg.height)
+        .attr('id', 'overlayLegend')
+        // don't want legend overlay on top of state overlay so make 
+        // it the exact size of the legend circles
+        .attr('width', Number(last_position) + Number(circle_radius)*2 - Number(first_position))
+        .attr('height', Number(circle_radius)*2)
+        .attr("transform", 
+            // need to transform so that they line up correctly
+            // the circles start getting placed at the top left corner of the svg
+            "translate(" + (legend_cfg.translate_x) + "," + (legend_cfg.translate_y) + ")")
         .style('opacity', 0)
-        .append('g')
-          .html(content)
-          .attr('id', 'overlayLegend')
-          .attr("transform", 
-            "translate(" + legend_cfg.translate_x + "," + legend_cfg.translate_y + ")");
+        .style("position", "absolute")
+        .html(content);
   
 }
 
@@ -67,4 +75,15 @@ function find_closest_point(click, dv_stats_data) {
   }
 }
 
-export {clone_states, clone_legend, add_circle_selector, find_closest_point};
+function add_placeholder(fig_cfg) {
+  // this is needed to keep the footer spaced correctly
+  // the key is to not add `position: absolute`
+  d3.select("#mainFig").append('svg')
+        .attr('id', 'overlayPlaceholder')
+        .attr('width', fig_cfg.width)
+        .attr('height', fig_cfg.height)
+        .attr('pointer-events', 'none')
+        .style('opacity', 0)
+        .attr("z-index", -100);
+}
+export {clone_states, clone_legend, add_circle_selector, find_closest_point, add_placeholder};

--- a/js/modules/interactivity.js
+++ b/js/modules/interactivity.js
@@ -24,12 +24,6 @@ function clone_legend(fig_cfg, legend_cfg) {
           .attr("transform", 
             "translate(" + legend_cfg.translate_x + "," + legend_cfg.translate_y + ")");
   
-  overlayLegend.selectAll("circle").on("click", function() {
-    
-    d3.select(this).attr("stroke", "orange").attr("stroke-width", 2);
-    var legend_color_str = d3.select(this).attr("fill");
-    console.log(legend_color_str);
-  });
 }
 
 function add_circle_selector() {

--- a/js/modules/interactivity.js
+++ b/js/modules/interactivity.js
@@ -1,0 +1,32 @@
+
+function find_closest_point(click, dv_stats_data) {
+  var point = d3.mouse(click);
+  var node;
+  var minDistance = Infinity;
+  
+  dv_stats_data.forEach(function (d) {
+    var dx = parseInt(d.x) - point[0];
+    var dy = parseInt(d.y) - point[1];
+    var distance = Math.sqrt((dx * dx) + (dy * dy));
+    if (distance < minDistance && distance < 10) {
+      minDistance = distance;
+      node = d;
+    }
+  });
+
+  if (node) {
+    //now we also have the data for a click event
+    d3.select("#siteHighlighter")
+      .attr("cx", node.x)
+      .attr("cy", node.y)
+      .style("opacity", 1);
+
+    console.log('you clicked siteID: ' + node.siteID);
+
+  }
+  else {
+    console.log('no site found');
+  }
+}
+
+export {find_closest_point};

--- a/js/modules/interactivity.js
+++ b/js/modules/interactivity.js
@@ -1,13 +1,35 @@
 
-function clone_states() {
+function clone_states(fig_cfg) {
   //clone states SVG for transparent click layer
   var content = d3.select("#plotarea").html();
-  var svg = d3.select("#mainFig").append('svg')
+  d3.select("#mainFig").append('svg')
         .html(content)
         .attr('id', 'overlayStates')
-        .attr('width', 960)
-        .attr('height', 600)
-        .style('opacity', 0);
+        .attr('width', fig_cfg.width)
+        .attr('height', fig_cfg.height)
+        .style('opacity', 0)
+        .style("position", "absolute");
+}
+
+function clone_legend(fig_cfg, legend_cfg) {
+  //clone legend SVG for transparent click layer
+  var content = d3.select("#legend").html();
+  var overlayLegend = d3.select("#mainFig").append('svg')
+        .attr('width', fig_cfg.width)
+        .attr('height', fig_cfg.height)
+        .style('opacity', 0)
+        .append('g')
+          .html(content)
+          .attr('id', 'overlayLegend')
+          .attr("transform", 
+            "translate(" + legend_cfg.translate_x + "," + legend_cfg.translate_y + ")");
+  
+  overlayLegend.selectAll("circle").on("click", function() {
+    
+    d3.select(this).attr("stroke", "orange").attr("stroke-width", 2);
+    var legend_color_str = d3.select(this).attr("fill");
+    console.log(legend_color_str);
+  });
 }
 
 function add_circle_selector() {
@@ -51,4 +73,4 @@ function find_closest_point(click, dv_stats_data) {
   }
 }
 
-export {clone_states, add_circle_selector, find_closest_point};
+export {clone_states, clone_legend, add_circle_selector, find_closest_point};

--- a/js/modules/interactivity.js
+++ b/js/modules/interactivity.js
@@ -1,4 +1,26 @@
 
+function clone_states() {
+  //clone states SVG for transparent click layer
+  var content = d3.select("#plotarea").html();
+  var svg = d3.select("#mainFig").append('svg')
+        .html(content)
+        .attr('id', 'overlayStates')
+        .attr('width', 960)
+        .attr('height', 600)
+        .style('opacity', 0);
+}
+
+function add_circle_selector() {
+  
+  // add circle to use to highlight selected points
+  d3.select("#plotarea").append('circle')
+    .attr("id", "siteHighlighter")
+    .attr("r", 8)
+    .attr("z-index", 100)
+    .style("fill", "blue")
+    .style("opacity", 0);
+}
+
 function find_closest_point(click, dv_stats_data) {
   var point = d3.mouse(click);
   var node;
@@ -29,4 +51,4 @@ function find_closest_point(click, dv_stats_data) {
   }
 }
 
-export {find_closest_point};
+export {clone_states, add_circle_selector, find_closest_point};


### PR DESCRIPTION
Still some tweaking left to do with how we want interactive behavior to be, but this uses canvas and we have points and the ability to hover over the legend and see categories changing. This doesn't have zoom capabilities yet - the underlying svg map we are using (a la `map-preprocess.yaml`) will likely need to change.

![gage_conditions_canvas](https://user-images.githubusercontent.com/13220910/45312371-81a51d80-b4f1-11e8-8792-216696dc0f84.gif)
