### PR TITLE
Fix percentiles

### DIFF
--- a/scripts/fetch/dv_data.R
+++ b/scripts/fetch/dv_data.R
@@ -14,19 +14,21 @@ fetch.dv_data <- function(viz){
   startDate <- paste0(year, "-01-01")
   endDate <- paste0(year, "-12-31")
   
-  dv_sites_data <- sapply(sites, FUN = function(x){
+  dv_sites_data <- lapply(sites, FUN = function(x){
     d <- renameNWISColumns(
       readNWISdata(service="dv",
                    site = x,
                    parameterCd="00060",
                    startDate = startDate,
                    endDate = endDate))
-    if (!is.null(d$Flow)){
-      d$Flow
+    if(nrow(d) > 0 && any(names(d) == "Flow")) {
+      d[, c("dateTime", "Flow")]
     } else {
-      NA
+      NULL
     }
   })
+  
+  names(dv_sites_data) <- sites
   
   jsonlite::write_json(dv_sites_data, viz[["location"]])
 }

--- a/scripts/process/dv_stats.R
+++ b/scripts/process/dv_stats.R
@@ -20,9 +20,14 @@ process.dv_stats <- function(viz){
   get_dv <- function(site_no){
     out <- rep(NA, length(site_no))
     for (i in 1:length(site_no)){
-      val <- data[[site_no[i]]][1L]
-      if (!is.null(val)){
-        out[i] <- val
+      data_site <- data[[site_no[i]]]
+      if (!is.null(data_site) && length(data_site) > 0 && 
+            "Flow" %in% names(data_site)){
+        # this assumes dateTime comes back as character
+        data_date <- filter(data_site, dateTime == date)
+        if (nrow(data_date) != 0){
+          out[i] <- data_date[["Flow"]]
+        }
       }
     }
     return(out)


### PR DESCRIPTION
We were seeing weird percentiles in this code compared to what it should have been. I hunted down why and found that it was an issue with the dv values, not the scaling or percentile categories. This does address #3.

The issue was that when we [fetched the data](https://github.com/USGS-VIZLAB/gage-conditions/blob/master/scripts/fetch/dv_data.R#L17-L29), we changed this code to fetch a full year to save fetch time in the future. [Here we are pulling a full year](https://github.com/USGS-VIZLAB/viz-scratch/blob/master/discharge_conditions_map/R/site_queries.R#L42-L43), but previously we just did a single date. So, we changed the code to use start and end dates for the year provided BUT we didn't edit the later code to factor in this change, so we ended up with [code during the process step that just picked the first value](https://github.com/USGS-VIZLAB/gage-conditions/blob/master/scripts/process/dv_stats.R#L23) from that list and using it as our date ("05-01" for now) when it isn't really that date. It's just the first non-NA data value which could be any date. 

Here is the result (which matches our expectations):
![image](https://user-images.githubusercontent.com/13220910/45828283-c84b0280-bcbd-11e8-9f1b-6765f53a0db3.png)
