### PR TITLE
Fix canvas points on top of footer & on top of legend

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -28,7 +28,7 @@ d3.select("#mainFig").select("svg")
 var canvas = d3.select("#mainFig").append('canvas')
       .attr('id', "mainCanvas")
       .attr('width', fig_cfg.width)
-      .attr('height', fig_cfg.width)
+      .attr('height', fig_cfg.height)
       .style("position", "absolute");
 
 var canvas_context = canvas.node().getContext('2d'),

--- a/js/app.js
+++ b/js/app.js
@@ -8,8 +8,8 @@ import {clone_states, clone_legend, add_circle_selector, find_closest_point, add
 
 // set up configs
 var fig_cfg = {
-      width: 960,
-      height: 600
+      width: d3.select('svg').attr("width"),
+      height: d3.select('svg').attr("height")
     },
     legend_cfg = {
       translate_x: 300,
@@ -35,12 +35,10 @@ d3.select("#mainFig").select("svg")
 // Make a second svg to put the legend and siteHighlighter into
 // This will allow the map to be below the canvas points,
 // But the siteHighlighter and legend to be above the canvas layer
-var svgwidth = d3.select('#mapSvg').attr("width"),
-    svgheight = d3.select('#mapSvg').attr("height");
 d3.select('#mainFig').append('svg')
   .attr("id", "mapExtras")
-  .attr("width", svgwidth)
-  .attr("height", svgheight)
+  .attr("width", fig_cfg.width)
+  .attr("height", fig_cfg.height)
   .style("position", "absolute")
   .style("z-index", z_indices.mapExtras);
 

--- a/js/app.js
+++ b/js/app.js
@@ -16,31 +16,52 @@ var fig_cfg = {
       translate_y: 40,
       circle_radius: 10,
       num_bins: 17
+    },
+    z_indices = {
+      underlayPlaceholder: -100,
+      mainCanvas: 10,
+      mapExtras: 20,
+      overlayStates: 30,
+      legend: 40,
+      overlayLegend: 50,
+      siteHighlighter: 100
     };
 
 // use existing svg element and add some attributes
 d3.select("#mainFig").select("svg")
-    .attr("id", "plotarea")
-    .style("z-index", -10)
+    .attr("id", "mapSvg")
     .style("position", "absolute");
+
+// Make a second svg to put the legend and siteHighlighter into
+// This will allow the map to be below the canvas points,
+// But the siteHighlighter and legend to be above the canvas layer
+var svgwidth = d3.select('#mapSvg').attr("width"),
+    svgheight = d3.select('#mapSvg').attr("height");
+d3.select('#mainFig').append('svg')
+  .attr("id", "mapExtras")
+  .attr("width", svgwidth)
+  .attr("height", svgheight)
+  .style("position", "absolute")
+  .style("z-index", z_indices.mapExtras);
 
 // create canvas layer
 var canvas = d3.select("#mainFig").append('canvas')
       .attr('id', "mainCanvas")
       .attr('width', fig_cfg.width)
       .attr('height', fig_cfg.height)
-      .style("position", "absolute");
+      .style("position", "absolute")
+      .style("z-index", z_indices.mainCanvas);
 
 var canvas_context = canvas.node().getContext('2d'),
     scale_colors_fxns = create_color_scale_function(legend_cfg),
     dv_stats_data = load_dv_data();
 
 // add different figure features
-add_color_legend(scale_colors_fxns, legend_cfg);
-add_circle_selector();
-clone_states(fig_cfg);
-clone_legend(fig_cfg, legend_cfg);
-add_placeholder(fig_cfg);
+add_color_legend(scale_colors_fxns, legend_cfg, z_indices);
+add_circle_selector(z_indices);
+clone_states(fig_cfg, z_indices);
+clone_legend(fig_cfg, legend_cfg, z_indices);
+add_placeholder(fig_cfg, z_indices);
 
 Promise.all([dv_stats_data]).then(function(data) {
   create_circles(data[0], canvas_context, scale_colors_fxns, fig_cfg, legend_cfg, 

--- a/js/app.js
+++ b/js/app.js
@@ -13,7 +13,7 @@ var fig_cfg = {
     },
     legend_cfg = {
       translate_x: 300,
-      translate_y: 40,
+      translate_y: 35,
       circle_radius: 10,
       num_bins: 17
     },

--- a/js/app.js
+++ b/js/app.js
@@ -55,11 +55,11 @@ var canvas_context = canvas.node().getContext('2d'),
     dv_stats_data = load_dv_data();
 
 // add different figure features
-add_color_legend(scale_colors_fxns, legend_cfg, z_indices);
-add_circle_selector(z_indices);
-clone_states(fig_cfg, z_indices);
-clone_legend(fig_cfg, legend_cfg, z_indices);
-add_placeholder(fig_cfg, z_indices);
+add_color_legend(scale_colors_fxns, legend_cfg, z_indices.legend);
+add_circle_selector(z_indices.siteHighlighter);
+clone_states(fig_cfg, z_indices.overlayStates);
+clone_legend(fig_cfg, legend_cfg, z_indices.overlayLegend);
+add_placeholder(fig_cfg, z_indices.underlayPlaceholder);
 
 Promise.all([dv_stats_data]).then(function(data) {
   create_circles(data[0], canvas_context, scale_colors_fxns, fig_cfg, legend_cfg, 

--- a/js/modules/circles.js
+++ b/js/modules/circles.js
@@ -86,13 +86,14 @@ function create_color_scale_function(legend_cfg) {
   });
 }
 
-function add_color_legend(scale_colors_fxn, legend_cfg) {
+function add_color_legend(scale_colors_fxn, legend_cfg, z_indices) {
   
   var num_colors = scale_colors_fxn.legend.range().length;
   
-  var legend = d3.select("#plotarea")
+  var legend = d3.select("#mapExtras")
     .append("g")
       .attr("id", "legend")
+      .style("z-index", z_indices.legend)
       .attr("transform", 
             "translate(" + legend_cfg.translate_x + "," + legend_cfg.translate_y + ")");
   

--- a/js/modules/circles.js
+++ b/js/modules/circles.js
@@ -126,7 +126,7 @@ function create_color_scale_function(legend_cfg) {
   });
 }
 
-function add_color_legend(scale_colors_fxn, legend_cfg, z_indices) {
+function add_color_legend(scale_colors_fxn, legend_cfg, z_index) {
   
   var num_colors = scale_colors_fxn.legend.range().length;
 
@@ -147,7 +147,7 @@ function add_color_legend(scale_colors_fxn, legend_cfg, z_indices) {
   var legend = d3.select("#mapExtras")
     .append("g")
       .attr("id", "legend")
-      .style("z-index", z_indices.legend)
+      .style("z-index", z_index)
       .attr("transform", 
             "translate(" + legend_cfg.translate_x + "," + legend_cfg.translate_y + ")");
   

--- a/js/modules/circles.js
+++ b/js/modules/circles.js
@@ -89,6 +89,20 @@ function create_color_scale_function(legend_cfg) {
 function add_color_legend(scale_colors_fxn, legend_cfg, z_indices) {
   
   var num_colors = scale_colors_fxn.legend.range().length;
+
+  // add white background behind legend so points don't crowd on zoom
+  var background = {
+    height: legend_cfg.circle_radius * 4,
+    width: (num_colors + 2.5) * 2 * legend_cfg.circle_radius,
+    tx: legend_cfg.translate_x - (2 * legend_cfg.circle_radius),
+    ty: legend_cfg.translate_y - (2 * legend_cfg.circle_radius)
+  };
+  
+  d3.select("#mapExtras").append("rect")
+    .attr("height", background.height)
+    .attr("width", background.width)
+    .style("fill", "white")
+    .attr("transform", "translate(" + background.tx + "," + background.ty + ")");
   
   var legend = d3.select("#mapExtras")
     .append("g")

--- a/js/modules/interactivity.js
+++ b/js/modules/interactivity.js
@@ -1,5 +1,5 @@
 
-function clone_states(fig_cfg, z_indices) {
+function clone_states(fig_cfg, z_index) {
   //clone states SVG for transparent click layer
   var content = d3.select("#mapSvg").html();
   d3.select("#mainFig").append('svg')
@@ -9,10 +9,10 @@ function clone_states(fig_cfg, z_indices) {
         .attr('height', fig_cfg.height)
         .style('opacity', 0)
         .style("position", "absolute")
-        .style('z-index', z_indices.overlayStates);
+        .style('z-index', z_index);
 }
 
-function clone_legend(fig_cfg, legend_cfg, z_indices) {
+function clone_legend(fig_cfg, legend_cfg, z_index) {
   var circle_radius = d3.select("#legend").select("circle").attr("r"),
       num_circles = d3.select("#legend").selectAll("circle").size(),
       first_position = d3.select("#legend").select("circle:first-child").attr("cx"),
@@ -32,7 +32,7 @@ function clone_legend(fig_cfg, legend_cfg, z_indices) {
             (legend_cfg.translate_y-circle_radius) + ")")
         .style('opacity', 0)
         .style("position", "absolute")
-        .style('z-index', z_indices.overlayLegend);
+        .style('z-index', z_index);
     
   // add circles
   overlayLegend.append('g')
@@ -45,13 +45,13 @@ function clone_legend(fig_cfg, legend_cfg, z_indices) {
       
 }
 
-function add_circle_selector(z_indices) {
+function add_circle_selector(z_index) {
   
   // add circle to use to highlight selected points
   d3.select("#mapExtras").append('circle')
     .attr("id", "siteHighlighter")
     .attr("r", 8)
-    .style("z_index", z_indices.siteHighlighter)
+    .style("z_index", z_index)
     .style("fill", "blue")
     .style("opacity", 0);
 }
@@ -86,7 +86,7 @@ function find_closest_point(click, dv_stats_data) {
   }
 }
 
-function add_placeholder(fig_cfg, z_indices) {
+function add_placeholder(fig_cfg, z_index) {
   // this is needed to keep the footer spaced correctly
   // the key is to not add `position: absolute`
   d3.select("#mainFig").append('svg')
@@ -95,7 +95,7 @@ function add_placeholder(fig_cfg, z_indices) {
         .attr('height', fig_cfg.height)
         .attr('pointer-events', 'none')
         .style('opacity', 0)
-        .style('z-index', z_indices.underlayPlaceholder);
+        .style('z-index', z_index);
 }
 
 //zooming stuff below here

--- a/js/modules/interactivity.js
+++ b/js/modules/interactivity.js
@@ -1,17 +1,18 @@
 
-function clone_states(fig_cfg) {
+function clone_states(fig_cfg, z_indices) {
   //clone states SVG for transparent click layer
-  var content = d3.select("#plotarea").html();
+  var content = d3.select("#mapSvg").html();
   d3.select("#mainFig").append('svg')
         .html(content)
         .attr('id', 'overlayStates')
         .attr('width', fig_cfg.width)
         .attr('height', fig_cfg.height)
         .style('opacity', 0)
-        .style("position", "absolute");
+        .style("position", "absolute")
+        .style('z-index', z_indices.overlayStates);
 }
 
-function clone_legend(fig_cfg, legend_cfg) {
+function clone_legend(fig_cfg, legend_cfg, z_indices) {
   var circle_radius = d3.select("#legend").select("circle").attr("r"),
       num_circles = d3.select("#legend").selectAll("circle").size(),
       first_position = d3.select("#legend").select("circle:first-child").attr("cx"),
@@ -30,7 +31,8 @@ function clone_legend(fig_cfg, legend_cfg) {
             "translate(" + (legend_cfg.translate_x-circle_radius) + "," + 
             (legend_cfg.translate_y-circle_radius) + ")")
         .style('opacity', 0)
-        .style("position", "absolute");
+        .style("position", "absolute")
+        .style('z-index', z_indices.overlayLegend);
     
   // add circles
   overlayLegend.append('g')
@@ -43,13 +45,13 @@ function clone_legend(fig_cfg, legend_cfg) {
       
 }
 
-function add_circle_selector() {
+function add_circle_selector(z_indices) {
   
   // add circle to use to highlight selected points
-  d3.select("#plotarea").append('circle')
+  d3.select("#mapExtras").append('circle')
     .attr("id", "siteHighlighter")
     .attr("r", 8)
-    .attr("z-index", 100)
+    .style("z_index", z_indices.siteHighlighter)
     .style("fill", "blue")
     .style("opacity", 0);
 }
@@ -84,16 +86,16 @@ function find_closest_point(click, dv_stats_data) {
   }
 }
 
-function add_placeholder(fig_cfg) {
+function add_placeholder(fig_cfg, z_indices) {
   // this is needed to keep the footer spaced correctly
   // the key is to not add `position: absolute`
   d3.select("#mainFig").append('svg')
-        .attr('id', 'overlayPlaceholder')
+        .attr('id', 'underlayPlaceholder')
         .attr('width', fig_cfg.width)
         .attr('height', fig_cfg.height)
         .attr('pointer-events', 'none')
         .style('opacity', 0)
-        .attr("z-index", -100);
+        .style('z-index', z_indices.underlayPlaceholder);
 }
 
 //zooming stuff below here
@@ -118,7 +120,7 @@ function clicked(d, fig_cfg, dv_data, scale_colors_fxns, legend_cfg) {
     // https://bl.ocks.org/mbostock/4699541
     // https://bl.ocks.org/mbostock/2206590
     // get bounding box and centroid from SVG path
-    var state = d3.select('#plotarea').select("#" + d);
+    var state = d3.select('#mapSvg').select("#" + d);
     var element = state.node();
     var bbox = element.getBBox();
     var centroid = [bbox.x + bbox.width / 2, bbox.y + bbox.height / 2];


### PR DESCRIPTION
Fixes #22. Simple fix to get circles out of footer - had the wrong height for the canvas element so it extended on top of the footer. Added a second svg to the map background called `mapExtras` that contains the legend and site selector point. That way, the map can be behind the canvas points, but the legend and any other svg additions can be on top of the legend points. Also, added white background around the legend so that on zoom, you can still see the legend points. Probably not the long-term fix, but good for MVP.

![image](https://user-images.githubusercontent.com/13220910/46210739-306d9a00-c2f7-11e8-93b4-9293c00ab35c.png)
