### PR TITLE
add different webpack build modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
     "description": "",
     "scripts": {
         "start": "webpack --mode development",
-        "dev": "webpack --mode development --watch"
+        "watch": "webpack --mode development --watch",
+        "dev": "webpack --mode development",
+        "beta": "webpack --mode production",
+        "prod": "webpack --mode production"
     },
     "dependencies": {
         "d3": "^5.5.0",

--- a/viz.yaml
+++ b/viz.yaml
@@ -10,9 +10,9 @@ info:
   required-packages:
     vizlab:
       repo: github
-      version: 0.3.8
+      version: 0.3.9
       name: USGS-VIZLAB/vizlab
-      ref: v0.3.8
+      ref: v0.3.9
     bit64:
       repo: CRAN
       version: 0.9-7


### PR DESCRIPTION
This allows us to change the `build_viz.R` script on different Jenkins jobs to run the dev version, or the production version. Also gives us the freedom to expand to more configuration by running different dev or prod `package.json` files as @mwernimont showed in the DS viz meeting today.

Running `vizlab::vizmake(webpack_build_cfg = "dev")` produces a `bundle.js` of 1.2 MB. Running `vizlab::vizmake(webpack_build_cfg = "beta")` actually minifies the scripts and produces a `bundle.js` of 250 kB.